### PR TITLE
fix mapping

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -167,3 +167,4 @@ def installNodes():
             addComfyUINodesToMapping(nodeElement)
             
 installNodes()
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']


### PR DESCRIPTION
The node doesn't load in comfyui without __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']